### PR TITLE
implement versioned cache, with manual cache no fullrebuild

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -4,13 +4,13 @@ on:
   schedule:
     - cron: "0 2 * * *"
   workflow_dispatch:
+    inputs:
+      no_cache:
+        description: 'Force full rebuild (no cache). Default: true for manual runs'
+        required: false
+        default: 'true'
   push:
     branches: [main]
-    # paths:
-    #   - "Dockerfile"
-    #   - "apps.json"
-    #   - "scripts/**"
-    #   - ".github/workflows/autobuild.yml"
 
 jobs:
   build-and-push:
@@ -20,10 +20,32 @@ jobs:
       DOCKER_HUB_USERNAME_SET: ${{ secrets.DOCKER_HUB_USERNAME != '' }}
       DOCKER_HUB_ACCESS_TOKEN_SET: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN != '' }}
       GHCR_PAT_IS_SET: ${{ secrets.GHCR_PAT != '' }}
+      NO_CACHE: 'false'  # default; overwritten for manual runs below
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+
+      - name: Set NO_CACHE for manual dispatch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          INPUT_NO_CACHE="${{ github.event.inputs.no_cache }}"
+          if [ -z "$INPUT_NO_CACHE" ]; then
+            echo "NO_CACHE=true" >> $GITHUB_ENV
+            echo "Manual dispatch: using NO_CACHE=true (default)"
+          else
+            case "${INPUT_NO_CACHE,,}" in
+              "1"|"true"|"yes")
+                echo "NO_CACHE=true" >> $GITHUB_ENV
+                echo "Manual dispatch: using NO_CACHE=true (from input)"
+                ;;
+              *)
+                echo "NO_CACHE=false" >> $GITHUB_ENV
+                echo "Manual dispatch: using NO_CACHE=false (from input)"
+                ;;
+            esac
+          fi
+
       - name: Free up disk space on runner
         run: |
           echo "Initial disk usage:"
@@ -82,7 +104,7 @@ jobs:
           echo "IMAGE_TAG_VERSION: $IMAGE_TAG_VERSION"
 
       - name: Free up disk space on runner
-        if: runner.os != 'Windows' # df and rm commands are for Linux/macOS
+        if: runner.os != 'Windows'
         run: |
           echo "Initial disk space:"
           df -h
@@ -113,6 +135,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GHCR_PAT }}
+
       - name: Encode Apps Json
         id: encode_apps_json
         run: |
@@ -150,8 +173,34 @@ jobs:
           echo "FINAL_TAGS=${TAGS}" >> $GITHUB_ENV
           echo "BUILD_ARGS=--build-arg ERPNEXT_VERSION=${{ env.ERPNext_VERSION_TAG }} --build-arg FRAPPE_BRANCH=${{ env.FRAPPE_BRANCH_FOR_BUILD }}" >> $GITHUB_ENV
 
+      - name: Compute and Log Cache Refs
+        run: |
+          # Compute the cache refs we will use and print them for debugging.
+          DH_USER="${{ secrets.DOCKER_HUB_USERNAME }}"
+          GH_OWNER="${{ github.repository_owner }}"
+          VERSION="${{ env.IMAGE_TAG_VERSION }}"
+
+          CACHE_DH_VERSIONED="${DH_USER}/erpnext:cache-${VERSION}"
+          CACHE_DH_GENERIC="${DH_USER}/erpnext:cache"
+          CACHE_GH_VERSIONED="ghcr.io/${GH_OWNER}/erp-next:cache-${VERSION}"
+          CACHE_GH_GENERIC="ghcr.io/${GH_OWNER}/erp-next:cache"
+
+          echo "CACHE_DH_VERSIONED=${CACHE_DH_VERSIONED}"
+          echo "CACHE_DH_GENERIC=${CACHE_DH_GENERIC}"
+          echo "CACHE_GH_VERSIONED=${CACHE_GH_VERSIONED}"
+          echo "CACHE_GH_GENERIC=${CACHE_GH_GENERIC}"
+
+          # Expose them as environment vars for the following build step
+          echo "CACHE_FROM_REF1=type=registry,ref=${CACHE_DH_VERSIONED}" >> $GITHUB_ENV
+          echo "CACHE_FROM_REF2=type=registry,ref=${CACHE_DH_GENERIC}" >> $GITHUB_ENV
+          echo "CACHE_FROM_REF3=type=registry,ref=${CACHE_GH_VERSIONED}" >> $GITHUB_ENV
+          echo "CACHE_FROM_REF4=type=registry,ref=${CACHE_GH_GENERIC}" >> $GITHUB_ENV
+
+          echo "CACHE_TO_REF1=type=registry,ref=${CACHE_DH_VERSIONED},mode=max" >> $GITHUB_ENV
+          echo "CACHE_TO_REF2=type=registry,ref=${CACHE_GH_VERSIONED},mode=max" >> $GITHUB_ENV
+
       - name: Build and Push Image
-        if: env.FINAL_TAGS != '' # Only run if tags were actually generated
+        if: env.FINAL_TAGS != ''
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -162,8 +211,15 @@ jobs:
             ${{ env.BUILD_ARGS }}
             APPS_JSON_BASE64=${{ env.APPS_JSON_BASE64 }}
           platforms: linux/amd64
-          cache-from: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/erpnext:cache
-          cache-to: type=registry,ref=${{ secrets.DOCKER_HUB_USERNAME }}/erpnext:cache,mode=max
+          cache-from: |
+            ${{ env.CACHE_FROM_REF1 }}
+            ${{ env.CACHE_FROM_REF2 }}
+            ${{ env.CACHE_FROM_REF3 }}
+            ${{ env.CACHE_FROM_REF4 }}
+          cache-to: |
+            ${{ env.CACHE_TO_REF1 }}
+            ${{ env.CACHE_TO_REF2 }}
+          no-cache: ${{ env.NO_CACHE }}
 
       - name: Build Summary
         run: |


### PR DESCRIPTION

- Use per-version registry cache refs (cache-<IMAGE_TAG_VERSION>) so builds for a specific ERPNext release reuse only that release’s cache.
- Keep a generic fallback cache for shared layers.
- Add workflow_dispatch input (no_cache) and default manual dispatch runs to NO_CACHE=true so manual builds perform a full rebuild by default.
- Add a Compute and Log Cache Refs step that prints the exact cache refs the workflow will use and exposes them to the build step so you can see which cache refs are consulted/published.
- Pass ERPNEXT_VERSION and FRAPPE_BRANCH build-args into the build and wire up no-cache to the build action.
- Why Prevents cross-version cache contamination (e.g., an image tagged 15.x containing files from a different ERPNext release) and makes it easy to force a full rebuild and to debug cache usage.

Notes / checklist before merging

- Ensure the Containerfile/Dockerfile uses ARG ERPNEXT_VERSION in the instruction(s) that fetch ERPNext (e.g., git clone --branch ${ERPNEXT_VERSION} ...) so layer invalidation works when the version changes.
- Ensure registry credentials (DOCKER_HUB_USERNAME & DOCKER_HUB_ACCESS_TOKEN and/or GHCR_PAT) are available in repo secrets so cache-from/cache-to refs can be read/written.
- Registry retention policies may remove cache tags; expect cache misses if the cache tag is removed.

How to verify after merging

- Trigger a manual workflow_dispatch and confirm the Compute and Log Cache Refs step prints versioned refs and NO_CACHE is true (for manual runs).
- Inspect the docker/build-push-action logs for cache hit/miss lines and referenced cache refs.
- Confirm per-version cache tags (e.g., erpnext:cache-15.80.0) appear in your registry after a build.
- Run a container from the built image and verify ERPNext version inside (check the app checkout .git/HEAD or version files).